### PR TITLE
Enable support of babel alias

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 
   "plugins": [
     "react",
+    "babel"
   ],
 
   "parser": "babel-eslint",
@@ -24,4 +25,9 @@ module.exports = {
     "react/jsx-filename-extension": "off",
     "react/no-unused-prop-types": "off",
   },
+  "settings": {
+    "import/resolver": {
+      "babel-module": {}
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-eslint": "^7.2.1",
     "eslint": "^3.18.0",
     "eslint-config-airbnb": "^14.1.0",
+    "eslint-import-resolver-babel-module": "^3.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3"


### PR DESCRIPTION
### Changelog

- This prevents ESLint from raising an `import/no-unresolved` error when we are using babel aliases.