### PR TITLE
`eslint-plugin-babel` for module resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eslint": "^3.18.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-import-resolver-babel-module": "^3.0.0",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3"


### PR DESCRIPTION
### Changelog

Add missing `eslint-plugin-babel` module